### PR TITLE
WIP - register dynamic refactoring

### DIFF
--- a/bench/1-register-loading.js
+++ b/bench/1-register-loading.js
@@ -672,7 +672,7 @@ function declaredRegisterLoader() {
   return loader;
 }
 
-suite.add('Importing mulitple trees at the same time with RegisterLoader', {
+suite.add('Importing multiple trees at the same time with RegisterLoader', {
   defer: true,
   fn: async function(deferred) {
     var loader = declaredRegisterLoader();
@@ -735,7 +735,7 @@ var allModules = [
   'export-star2.js'
 ];
 
-suite.add('Importing mulitple trees at the same time with SystemJS', {
+suite.add('Importing multiple trees at the same time with SystemJS', {
   defer: true,
   fn: async function(deferred) {
     var loader = declaredSystemJSLoader();
@@ -744,11 +744,11 @@ suite.add('Importing mulitple trees at the same time with SystemJS', {
   }
 });
 
-suite.add('Importing a single registered module with SystemJS', {
+suite.add('Importing a deep tree of modules with SystemJS', {
   defer: true,
   fn: async function(deferred) {
     var loader = declaredSystemJSLoader();
-    await loader.import('no-imports.js');
+    await loader.import('_a.js');
     deferred.resolve();
   }
 });
@@ -762,11 +762,11 @@ suite.add('Importing a module with deps with SystemJS', {
   }
 });
 
-suite.add('Importing a deep tree of modules with SystemJS', {
+suite.add('Importing a single registered module with SystemJS', {
   defer: true,
   fn: async function(deferred) {
     var loader = declaredSystemJSLoader();
-    await loader.import('_a.js');
+    await loader.import('no-imports.js');
     deferred.resolve();
   }
 });

--- a/bench/runner.js
+++ b/bench/runner.js
@@ -6,6 +6,12 @@ var benchmarks = fs.readdirSync('bench').filter(function(testName) {
   return testName != 'runner.js' && testName.endsWith('.js')
 });
 
+process.on('unhandledRejection', function (e) {
+  setTimeout(function () {
+    throw e;
+  });
+});
+
 function runNextBenchmark() {
   var nextBenchmark = benchmarks.shift();
 

--- a/core/common.js
+++ b/core/common.js
@@ -69,7 +69,7 @@ if (baseURI[baseURI.length - 1] !== '/')
  * LoaderError with chaining for loader stacks
  */
 var errArgs = new Error(0, '_').fileName == '_';
-function LoaderError__Check_error_message_above_for_loader_stack (childErr, newMessage) {
+function LoaderError__Check_error_message_for_loader_stack (childErr, newMessage) {
   // Convert file:/// URLs to paths in Node
   if (!isBrowser)
     newMessage = newMessage.replace(isWindows ? /file:\/\/\//g : /file:\/\//g, '');
@@ -95,43 +95,4 @@ function LoaderError__Check_error_message_above_for_loader_stack (childErr, newM
 
   return err;
 }
-export { LoaderError__Check_error_message_above_for_loader_stack as addToError }
-
-
-
-/*
- * Convert a CJS module.exports into a valid object for new Module:
- *
- *   new Module(getEsModule(module.exports))
- *
- * Sets the default value to the module, while also reading off named exports carefully.
- */
-export function getEsModule(exports, moduleObj) {
-  moduleObj = moduleObj || {};
-  // don't trigger getters/setters in environments that support them
-  if ((typeof exports == 'object' || typeof exports == 'function') && exports !== envGlobal) {
-      for (var p in exports) {
-        // The default property is copied to esModule later on
-        if (p === 'default')
-          continue;
-        defineOrCopyProperty(moduleObj, exports, p);
-      }
-  }
-  esModule['default'] = exports;
-  defineProperty(moduleObj, '__useDefault', { value: true });
-  return moduleObj;
-}
-
-function defineOrCopyProperty(targetObj, sourceObj, propName) {
-  try {
-    var d;
-    if (d = Object.getOwnPropertyDescriptor(sourceObj, propName))
-      defineProperty(targetObj, propName, d);
-  }
-  catch (ex) {
-    // Object.getOwnPropertyDescriptor threw an exception, fall back to normal set property
-    // we dont need hasOwnProperty here because getOwnPropertyDescriptor would have returned undefined above
-    targetObj[propName] = sourceObj[propName];
-    return false;
-  }
-}
+export { LoaderError__Check_error_message_for_loader_stack as addToError }

--- a/core/common.js
+++ b/core/common.js
@@ -96,3 +96,42 @@ function LoaderError__Check_error_message_above_for_loader_stack (childErr, newM
   return err;
 }
 export { LoaderError__Check_error_message_above_for_loader_stack as addToError }
+
+
+
+/*
+ * Convert a CJS module.exports into a valid object for new Module:
+ *
+ *   new Module(getEsModule(module.exports))
+ *
+ * Sets the default value to the module, while also reading off named exports carefully.
+ */
+export function getEsModule(exports, moduleObj) {
+  moduleObj = moduleObj || {};
+  // don't trigger getters/setters in environments that support them
+  if ((typeof exports == 'object' || typeof exports == 'function') && exports !== envGlobal) {
+      for (var p in exports) {
+        // The default property is copied to esModule later on
+        if (p === 'default')
+          continue;
+        defineOrCopyProperty(moduleObj, exports, p);
+      }
+  }
+  esModule['default'] = exports;
+  defineProperty(moduleObj, '__useDefault', { value: true });
+  return moduleObj;
+}
+
+function defineOrCopyProperty(targetObj, sourceObj, propName) {
+  try {
+    var d;
+    if (d = Object.getOwnPropertyDescriptor(sourceObj, propName))
+      defineProperty(targetObj, propName, d);
+  }
+  catch (ex) {
+    // Object.getOwnPropertyDescriptor threw an exception, fall back to normal set property
+    // we dont need hasOwnProperty here because getOwnPropertyDescriptor would have returned undefined above
+    targetObj[propName] = sourceObj[propName];
+    return false;
+  }
+}

--- a/core/loader-polyfill.js
+++ b/core/loader-polyfill.js
@@ -181,6 +181,7 @@ Registry.prototype.delete = function (key) {
 var EVALUATE = createSymbol('evaluate');
 var EVALUATION_CONTEXT = createSymbol('evaluationContext');
 var BASE_OBJECT = createSymbol('baseObject');
+var EVALUATE_ERROR = createSymbol()
 
 // 8.3.1 Reflect.Module
 /*
@@ -267,15 +268,12 @@ Module.evaluate = function (ns) {
   if (evaluate) {
     ns[EVALUATE] = undefined;
     var err = doEvaluate(evaluate, ns[EVALUATION_CONTEXT]);
+    ns[EVALUATION_CONTEXT] = undefined;
     if (err) {
-      // effectively cache the evaluation error
-      // to ensure we don't re-run evaluation of the module
-      // before it has been cleared off the registry
-      Object.defineProperty(ns, EVALUATE, {
-        get: function() {
-          throw err;
-        }
-      });
+      // cache the error
+      ns[EVALUATE] = function () {
+        throw err;
+      };
       throw err;
     }
     Object.keys(ns[BASE_OBJECT]).forEach(extendNamespace, ns);

--- a/core/register-loader.js
+++ b/core/register-loader.js
@@ -104,7 +104,7 @@ function createLoadRecord (key, registration) {
 
       execute: undefined,
 
-      // this lock is necessary just in case a top level execure is called
+      // this lock is necessary just in case a top level execute is called
       // while alreadu executing
       evaluated: false,
 
@@ -190,7 +190,7 @@ RegisterLoader.prototype[Loader.resolveInstantiate] = function (key, parentKey) 
 function ensureInstantiate (loader, load) {
   var link = load.linkRecord;
 
-  if (!link)
+  if (!link || link.allInstantiated)
     return Promise.resolve(load);
 
   if (link.error)
@@ -221,10 +221,10 @@ function ensureInstantiateAllDeps (loader, load, seen) {
 
   // skip if already executed / already all instantiated
   if (!link || link.allInstantiated)
-    return load;
+    return Promise.resolve(load);
 
   if (seen.indexOf(load) !== -1)
-    return load;
+    return Promise.resolve(load);
   seen.push(load);
 
   var instantiateDepsPromises = Array(link.dependencies.length);
@@ -456,6 +456,7 @@ function ensureRegister (load) {
     throw new TypeError('Module instantiation did not call an anonymous or correctly named System.register.');
 
   link.dependencies = registration[0];
+
   load.importerSetters = [];
 
   // dynamic module

--- a/core/register-loader.js
+++ b/core/register-loader.js
@@ -203,7 +203,7 @@ function resolveInstantiate (loader, key, parentKey, registry, registerRegistry,
   });
 }
 
-function instantiate (loader, load, link, registry) {
+function instantiate (loader, load, link, registry, registerRegistry) {
   return link.instantiatePromise || (link.instantiatePromise =
   Promise.resolve(loader.instantiate(load.key, link.metadata))
   .then(function (instantiation) {
@@ -213,6 +213,7 @@ function instantiate (loader, load, link, registry) {
         throw new TypeError('Instantiate did not return a valid Module object.');
 
       load.linked = true;
+      registerRegistry[load.key] = undefined;
       if (loader.trace)
         traceLoad(load, link);
       return registry[load.key] = load.module = instantiation;
@@ -576,7 +577,8 @@ function doEvaluate (load, link, seen) {
   // extra guard in case of overlapping execution graphs
   // eg a Module.evaluate call within a Module.evaluate body
   link.evaluated = true;
-  err = doExecute(link.execute, link.setters && nullContext);
+  if (link.execute)
+    err = doExecute(link.execute, link.setters && nullContext);
 
   if (err)
     return link.error = addToError(err, 'Evaluating ' + load.key);

--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
     }
   ],
   "devDependencies": {
-    "babel-cli": "^6.11.4",
-    "babel-plugin-transform-async-to-generator": "^6.8.0",
-    "babel-plugin-transform-es2015-modules-systemjs": "^6.12.0",
+    "babel-cli": "^6.16.0",
+    "babel-plugin-transform-async-to-generator": "^6.16.0",
+    "babel-plugin-transform-es2015-modules-systemjs": "^6.14.0",
     "benchmark": "^2.1.1",
     "mocha": "^3.0.2",
     "node-es-module-loader": "^0.1.1",

--- a/test/3-register-loader.js
+++ b/test/3-register-loader.js
@@ -86,8 +86,7 @@ describe('System Register Loader', function() {
       assert.equal(m1.output2, 'test circular 1');
     });
 
-    // pending https://github.com/babel/babel/pull/3650
-    it.skip('should update circular dependencies', async function() {
+    it('should update circular dependencies', async function() {
       var m = await loader.import('./even.js');
       assert.equal(m.counter, 1);
       assert(m.even(10));

--- a/test/fixtures/dynamic-modules/basic-exports.js
+++ b/test/fixtures/dynamic-modules/basic-exports.js
@@ -1,0 +1,6 @@
+System.registerDynamic([], true, function(require, exports, module) {
+  module.exports = function() {
+    return 'ok';
+  };
+  module.exports.named = 'name!';
+});

--- a/test/fixtures/dynamic-modules/mixed-bundle.js
+++ b/test/fixtures/dynamic-modules/mixed-bundle.js
@@ -1,0 +1,55 @@
+System.register("tree/third", [], function($__export) {
+  var some;
+  return {
+    setters: [],
+    execute: function() {
+      some = $__export('some', 'exports');
+    }
+  };
+});
+
+System.registerDynamic("tree/cjs", [], true, function(require, exports, __moduleName) {
+  var module = { exports: exports };
+  exports.cjs = true;
+  return module.exports;
+});
+
+System.registerDynamic("tree/jquery", [], false, function(require, exports, __moduleName) {
+  return {};
+});
+
+System.register("tree/second", ["./third", "./cjs"], function($__export) {
+  "use strict";
+  var q;
+  return {
+    setters: [function() {}, function() {}],
+    execute: function() {
+      q = $__export('q', 4);
+    }
+  };
+});
+
+System.registerDynamic("tree/global", ['./jquery'], false, function(__require, __exports, __moduleName) {
+  return 'output';
+});
+
+System.registerDynamic("tree/amd", ['./global'], false, function() {
+  return { is: 'amd' };
+});
+
+
+System.register("tree/first", ["./second", "./amd"], function($__export) {
+  "use strict";
+  var __moduleName = "tree/first";
+  var p;
+  return {
+    setters: [function(s) {
+      $__export('q', s.q);
+    }, function(a) {
+      $__export('a', a.default);
+    }],
+    execute: function() {
+      p = $__export('p', 5);
+    }
+  };
+});


### PR DESCRIPTION
The original plan was to implement `System.registerDynamic` (the wrapper format for CommonJS bundling) as a layer on top of this loader in SystemJS, but it has turned out that due to the complexities of the linking algorithm, performance and also integrating the ideas from the latest TC39, it really is best to combine the implementation with `System.register`.

This is the first step of that work here, pending further testing and performance work.